### PR TITLE
イメージタグにスラッシュが使えないことを検証する

### DIFF
--- a/.github/workflows/manual-test.yaml
+++ b/.github/workflows/manual-test.yaml
@@ -30,10 +30,10 @@ jobs:
         id: setup-image-tag
         run: |
           commit_hash="$(echo ${{ github.sha }} | cut -c 1-7)"
-          docker_image_tag="${{ inputs.image_tag_name }}-${commit_hash}"
-          echo "docker_image_tag: $docker_image_tag"
-          echo "docker_image_tag=$docker_image_tag" >> "$GITHUB_OUTPUT"
+          docker_image_name="echo-test:${{ inputs.image_tag_name }}-${commit_hash}"
+          echo "docker_image_name: $docker_image_name"
+          echo "docker_image_name=$docker_image_name" >> "$GITHUB_OUTPUT"
       - name: Build docker image and run
         run: |
-          docker build . -t ${{ steps.setup-image-tag.outputs.docker_image_tag }}
-          docker run --rm -t ${{ steps.setup-image-tag.outputs.docker_image_tag }}
+          docker build . -t ${{ steps.setup-image-tag.outputs.docker_image_name }}
+          docker run --rm -t ${{ steps.setup-image-tag.outputs.docker_image_name }}


### PR DESCRIPTION
## 概要

手動実行時に渡す入力をdocker tagに使用する